### PR TITLE
Revert "minor cleaning"

### DIFF
--- a/EqDendSets&Ops-new.tex
+++ b/EqDendSets&Ops-new.tex
@@ -3777,6 +3777,24 @@ with $i(0) = F_{\bar{\alpha}}a,i(1) = \bar{b}$ yields the result.
 {\color{red} HERE}
 
 
+\begin{lemma}
+      Local genuine trivial cofibrations with cofibrant source and local genuine cofibrations in $\Op^G(\V)$ are closed under transfinite composition.
+\end{lemma}
+
+\begin{proof}
+      Since for any $\mathfrak C$-signature $C \in G \ltimes \SC^{op}$ and any map of $\mathfrak C$-colored operads $f$ we have that
+      the restriction map
+      $\V^{\Aut(f(C))}_{gen} \to \V^{\Aut(C)}_{gen}$
+      is left Quillen,
+      and any transfinite composition of operads locally is of the form
+      \begin{equation}
+            \O_0(C) \to \O_1(F_1(C)) \to \O_2(F_2(C)) \to \dots   
+      \end{equation}
+      in $\V^{\Aut(C)}_{gen}$
+      for $F_\alpha$ the (transfinite) composite $\O_0 \to \O_1 \to \dots \to \O_\alpha$,
+      the result follows.
+\end{proof}
+\todo[inline]{to remove ``cofibrant source'' need something like $\otimes$-perfect}
 
 
 


### PR DESCRIPTION
Reverts Dendroidal/EqDendSetsOps#219

The situation with the transfinite composition of local cofibrations proposition is subtler than the current discussion (which right now is no proof), definitely requires something like \otimes-perfectness/monoid axiom.