### PR TITLE
Unresaonably specific global monoid axiom

### DIFF
--- a/EqDendSets&Ops-new.tex
+++ b/EqDendSets&Ops-new.tex
@@ -19,7 +19,7 @@
 \input{commands.tex}%
 
 
-%-------- Tikz ---------------------------
+% -------- Tikz ---------------------------
 
 \usepackage{tikz}%
 \usetikzlibrary{matrix,arrows,decorations.pathmorphing,
@@ -42,7 +42,7 @@ cd,patterns,calc}
 \usepackage{ifdraft}
 \ifdraft{
   \color[RGB]{63,63,63}
-%  \pagecolor[RGB]{220,220,204}
+  \pagecolor[RGB]{220,220,204}
   \usepackage{showkeys}
   \usepackage{geometry}
   \usepackage{todonotes}
@@ -2643,12 +2643,16 @@ and the induction step following from the already established cofibrancy of the 
       \begin{enumerate}[label = (\roman*)]
       \item genuine model structures on $\V^\G$ exist,
       \item cofibrant symmetric pushout powers,
-      \item global monoid axiom:
+      \item \textit{unreasonably specific global monoid axiom} (\textbf{USGMA}):
+
+            Let $\mathcal J^{\otimes}_G$ denote the class of \textit{global $\otimes$-trivial-cofibrations} in $\V^G$,
+            given by transfinite composites of maps from
             \begin{equation}
                   \label{GLOBMONAX_EQ}
-                  G \cdot_H \left(\mathcal J \otimes \V^H\right)\text{-cell} \subseteq \mathcal W^G
+                  \bigcup_{H \to G} \left(G \cdot_H \left(\mathcal J \otimes \V^H\right)\text{-cof}\right).
             \end{equation}
-            for all homomorphisms of finite groups $H \to G$.
+
+            The \textbf{USGMA} demands that $\mathcal J^{\otimes}_G$ is contained in $\mathcal W^G$ for all $G$.            
       \end{enumerate}
 \end{remark}
 
@@ -2674,68 +2678,109 @@ and the induction step following from the already established cofibrancy of the 
           & =
           \left( G \cdot_H \left( \left(\mathcal J \otimes \V^H\right)\text{-cell} \right) \right) \mathbin{\cap} \mathcal W^G
         \end{align*}
-        In particular the parentheses in \eqref{GLOBMONAX_EQ} are not ambiguous.
+        In particular, there is no difference in \eqref{GLOBMONAX_EQ} whether ``-cof'' refers to $\mathcal J \otimes \V^H$ or it's induction.
   \end{remark}
 }
 
 {\color{blue} % ------------------------------ COLOR BLUE ------------------------------
   \begin{lemma}
         Suppose genuine model structures exist for $\V$.
-        Then any of the following conditions imply the global monoid axiom.
+        Then any of the following conditions imply the \textbf{USGMA}.
         \begin{enumerate}[label = (\alph*)]
-        \item All objects in $\V^G$ are cofibrant (Propositions \ref{EQQUILADJ PROP} and \ref{RESGEN PROP}).
         \item $J \otimes \V^G \subseteq J^G\text{-cell}$ (Proposition \ref{EQQUILADJ PROP}).
-        \item $(J \otimes \V^G)\text{-cell}$ are genuine weak equivalences between cofibrant objects (Ken Brown's Lemma and Proposition \ref{EQQUILADJ PROP}).
+
+              In particular, this holds if all objects in $\V^G$ are cofibrant (Propositions \ref{EQQUILADJ PROP} and \ref{RESGEN PROP}).
+              % \item $(J \otimes \V^G)\text{-cell}$ are genuine weak equivalences between cofibrant objects (Ken Brown's Lemma and Proposition \ref{EQQUILADJ PROP}).
+              % ---------- This no longer works: in the application, this would mean we get genuine $\Aut{\vect U}$- and then $\Aut(\vect C)$-equivalences for each $k$, but not that these compose to remain weak equivalences in $\Aut(\vect C)$.
         \end{enumerate}
   \end{lemma}
   \todo[inline]{can we get better than this using ``fixed points of trivial cofibs are cofibs'' + ``monoid axiom''?}
 
-  \textbf{For J-Cell Lemma:}
-
-  \begin{definition}
-        Given a saturated class $K$ in $\V$, we say the weak equivalences $\mathcal W$ in $\V$ are \textit{$K$-perfect} if
-        $\mathcal W$ is stable under filtered colimits of maps in $K$; that is,
-        for any filtered category $\mathcal D$, we have a lifting
-        \[
-              \begin{tikzcd}
-                    &
-                    \mathcal W \arrow[d, hookrightarrow]
-                    \\
-                    \Fun_K(\mathcal D, \V) \arrow[r, "\colim"'] \arrow[ur, dashed]
-                    &
-                    \V
-              \end{tikzcd}
-        \]
-        where $\Fun_K(\mathcal D, \V) \subseteq \Fun(\mathcal D, \V)$ is the wide subcategory consisting of those natural transformations consisting of maps in $K$,
-        and $\mathcal W \subseteq \V$ is the wide subcategory defined by $\mathcal W$.
-  \end{definition}
-  
-  \begin{definition}
-        Given a homomorphism of finite groups $H \to G$, denote by $\mathcal I^\otimes_{H,G}$ the class of maps in $\V^G$ given by
-        \begin{equation}
-              \label{IOTIMESHG_EQ}
-              \mathcal I^{\otimes}_{H,G} := G \cdot_H \left(\mathcal I \otimes \V^H\right)\text{-cell}.
-        \end{equation}
-        We say $\V$ is \textit{globally $\otimes$-perfect} if
-        the class of genuine weak equivalences $\mathcal W^G \subseteq \V^G$ is $\mathcal I^\otimes_{H,G}$-perfect for all $H \to G$.
-  \end{definition}
-
-  \todo[inline]{similarly, can we break this down?}
-  
-  \begin{remark}
-        By an argument analogous to Remark \ref{GLOBMONAX_REM}, the class of maps $\mathcal I^{\otimes}_{H,G} \mathbin{\cap} \mathcal W^G$ is equal to the class of maps
-        \begin{equation}
-              G \cdot_H \left( \left(\mathcal I^H\text{-cof}\right) \otimes \V^H \right) \mathbin{\cap} \mathcal W^G.
-        \end{equation}
-  \end{remark}
-
-  \begin{corollary}[cf. Corollary \ref{LGC_COR}]
-        If $\V$ is globally $\otimes$-perfect, then 
-        any cofibration in $\Op^G_{\mathfrak C}$ is a local $\otimes$-cofibration.
-  \end{corollary}
+  \begin{lemma}
+        $\F$-trivial cofibrations in $\Op^G_{\mathfrak C}$ are levelwise global $\otimes$-trivial-cofibrations.
+  \end{lemma}
   \begin{proof}
-        This follows from the proof of Theorem \ref{THM1_C}.
+        This follows by the proof of Theorem \ref{THM1_C}.
   \end{proof}
+
+  \begin{lemma}
+        The \textbf{USGMA} implies Proposition \ref{J-CELL_PROP}.
+  \end{lemma}
+  \begin{proof}
+        The proof of \ref{J-CELL_PROP} shows that pushouts of generating trivial cofibrations are either
+        \begin{enumerate}
+        \item $\F$-trivial cofibrations
+        \item a composite of an $\F$-trivial cofibration with an essentially-surjective local isomorphism.
+        \end{enumerate}
+        All three of these maps are essentially surjective AND global $\otimes$-trivial-cofibrations,
+        and Lemma \ref{TRANSCOMP_ES_LEM} and \textbf{USGMA} imply that any transfinite composite of such maps is
+        essentially surjective and a levelwise weak equivalence.
+  \end{proof}
+
+  % \textbf{For J-Cell Lemma:}
+
+  % \begin{definition}
+  %       Given a saturated class $K$ in $\V$, we say the weak equivalences $\mathcal W$ in $\V$ are \textit{$K$-perfect} if
+  %       $\mathcal W$ is stable under filtered colimits of maps in $K$; that is,
+  %       for any filtered category $\mathcal D$, we have a lifting
+  %       \[
+  %             \begin{tikzcd}
+  %                   &
+  %                   \mathcal W \arrow[d, hookrightarrow]
+  %                   \\
+  %                   \Fun_{K \cap \mathcal W}(\mathcal D, \V) \arrow[r, "\colim"'] \arrow[ur, dashed]
+  %                   &
+  %                   \V
+  %             \end{tikzcd}
+  %       \]
+  %       where $\Fun_{K \cap \mathcal W}(\mathcal D, \V) \subseteq \Fun(\mathcal D, \V)$ is the wide subcategory consisting of those natural transformations consisting of maps in $K \cap \mathcal W$,
+  %       and $\mathcal W \subseteq \V$ is the wide subcategory defined by $\mathcal W$.
+  % \end{definition}
+  
+  % \begin{definition}
+  %       Given a homomorphism of finite groups $H \to G$, denote by $\mathcal I^\otimes_{H,G}$ the class of maps in $\V^G$ given by
+  %       \begin{equation}
+  %             \label{IOTIMESHG_EQ}
+  %             \mathcal I^{\otimes}_{H,G} := G \cdot_H \left(\mathcal I \otimes \V^H\right)\text{-cell}.
+  %       \end{equation}
+  %       A map in $\V^G$ is a \textit{global $\otimes$-cofibration} if it is in some $\mathcal I^{\otimes}_{H,G}$ for some $H \to G$.
+        
+  %       We say $\V$ is \textit{globally $\otimes$-perfect} if
+  %       the class of genuine weak equivalences $\mathcal W^G \subseteq \V^G$ is $\mathcal I^\otimes_{H,G}$-perfect for all $H \to G$.
+  % \end{definition}
+
+  % \begin{lemma}
+  %       Suppose genuine model structures exist for $\V$. Then any of the following conditions imply that $\V$ is globally $\otimes$-perfect:
+  %       \begin{enumerate}
+  %       \item $\mathcal I \otimes \V^G \subseteq I^G\text{-cell}$ (Proposition \ref{EQQUILADJ PROP}).
+
+  %             In particular, this holds if all objects in $\V^G$ are cofibrant (Propositions \ref{EQQUILADJ PROP} and \ref{RESGEN PROP}).
+  %       \item 
+  %       \end{enumerate}
+  % \end{lemma}
+  
+  % \todo[inline]{similarly, can we break this down?}
+  
+  % \begin{remark}
+  %       By an argument analogous to Remark \ref{GLOBMONAX_REM}, the class of maps $\mathcal I^{\otimes}_{H,G} \mathbin{\cap} \mathcal W^G$ is equal to the class of maps
+  %       \begin{equation}
+  %             G \cdot_H \left( \left(\mathcal I^H\text{-cof}\right) \otimes \V^H \right) \mathbin{\cap} \mathcal W^G.
+  %       \end{equation}
+  % \end{remark}
+
+
+  
+  % \begin{corollary}[cf. Corollary \ref{LGC_COR}]
+  %       If $\V$ is globally $\otimes$-perfect, then 
+  %       any cofibration in $\Op^G_{\mathfrak C}$ is levelwise a global $\otimes$-cofibration.
+  % \end{corollary}
+  % \begin{proof}
+  %       This follows from the proof of Theorem \ref{THM1_C}.
+  % \end{proof}
+
+  % \begin{lemma}
+  %       Global $\otimes$-cofibrations in $\V^G$ are closed under transfinite composition.
+  % \end{lemma}
 
 } % ----------------------------------- COLOR BLUE -----------------------------------
 
@@ -5518,7 +5563,7 @@ where $\1$ defined as in Definition \ref{PL_ES_DEFN}, and $\mathscr{G}$ is a gen
 
 
 
-\iffalse%
+
 
 
 
@@ -14263,7 +14308,7 @@ then any map in $\mathcal D$ with cofibrant source may be factored into a map in
 
 
 
-\fi%
+
 
 
 \newpage


### PR DESCRIPTION
The monoid axiom does not imply tensor-perfectness --- BUT I think we/BM13 don't actually need tensor-perfectness.
The specific axiom we need to make THM1 run (USGMA) also implies J-CELL_PROP.